### PR TITLE
fix: only open prs were searched if since and until were nil

### DIFF
--- a/service/github_service.go
+++ b/service/github_service.go
@@ -97,6 +97,8 @@ func (c *gitHubServiceImpl) ListMergedPullRequests(option ListMergedPullRequests
 	if since != "*" || until != "*" {
 		// https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#query-for-dates
 		opts = append(opts, "--search", fmt.Sprintf("merged:%s..%s", since, until))
+	} else {
+		opts = append(opts, "is:merged")
 	}
 
 	// serialized attributes

--- a/service/github_service.go
+++ b/service/github_service.go
@@ -98,7 +98,7 @@ func (c *gitHubServiceImpl) ListMergedPullRequests(option ListMergedPullRequests
 		// https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#query-for-dates
 		opts = append(opts, "--search", fmt.Sprintf("merged:%s..%s", since, until))
 	} else {
-		opts = append(opts, "is:merged")
+		opts = append(opts, "--search", "is:merged")
 	}
 
 	// serialized attributes


### PR DESCRIPTION
`is:merged` is required if `merged:...` option is missing.