### PR TITLE
chore: Set max token to 1024 but it's experimental

### DIFF
--- a/service/chatgpt_service.go
+++ b/service/chatgpt_service.go
@@ -59,7 +59,7 @@ func (s *chatGPTServiceImpl) GetSingleAnswer(prs []*types.PullRequest, templateT
 	resp, err := s.client.CreateChatCompletion(s.ctx, openai.ChatCompletionRequest{
 		Model:     openai.GPT3Dot5Turbo,
 		Messages:  messages,
-		MaxTokens: 500,
+		MaxTokens: 1024, // TODO experimental
 	})
 
 	if err != nil {


### PR DESCRIPTION
The default value is 2048 tokens and we can set it to at most 4096 tokens.